### PR TITLE
Changed new contract permissions condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ This plugin allows you to:
 Installation
 ------------ 
 
-Easiest way to get this plugin: 
+1. go to your redmine plugins directory (eg cd /opt/redmine/plugins)
+2. run git clone for the project (eg git clone https://github.com/bsyzek/redmine-contracts-with-time-tracking-plugin.git plugins/contracts or git clone https://github.com/Sam-R/redmine-contracts-with-time-tracking-plugin.git )
+3. Rename the checked out project to contracts ( mv redmine-contracts-with-time-tracking-plugin contracts )
+4. go to your Redmine root directory ( eg cd /opt/redmine )
+5. run 'rake redmine:plugins:migrate RAILS_ENV=production'
+6. Restart your webserver ( eg service apache2 restart )
 
-1. run 'git submodule add https://github.com/bsyzek/redmine-contracts-with-time-tracking-plugin.git plugins/contracts' from your redmine root directory
-Note : use the git clone instead of git submodule add if your install folder is not part of a git project. 
-
-2. run 'rake redmine:plugins:migrate RAILS_ENV=production' from your redmine root directory 
 
 Screenshots
 -----------

--- a/app/views/contracts/index.html.erb
+++ b/app/views/contracts/index.html.erb
@@ -1,6 +1,7 @@
 <div class="contextual">
-  <% if (@project != nil) && (User.current.roles_for_project(@project).first.permissions.include?(:create_contracts)) %>
-    <%= link_to l(:label_new_contract), { :controller => 'contracts', :action => 'new', :project_id => @project.identifier }, :class => 'icon icon-add' %>
+  <%= link_to_if_authorized l(:label_new_contract), { :controller => 'contracts', :action => 'new', :project_id => @project.identifier }, :class => 'icon icon-add' %>
+  <% if @project.categories.length > 0 %>
+    <%= link_to_if_authorized l(:title_create_article), { :controller => 'articles', :action => 'new', :project_id => @project}, :class => 'icon icon-add' %>
   <% end %>
 </div>
 

--- a/init.rb
+++ b/init.rb
@@ -1,3 +1,7 @@
+
+# If using dev mode require redmine?
+require 'redmine'
+
 require_dependency 'contracts/hooks/hooks'
 require_dependency 'contracts/patches/time_entry_patch'
 require_dependency 'contracts/patches/project_patch'
@@ -12,7 +16,8 @@ Redmine::Plugin.register :contracts do
   version '1.2.0'
   url 'https://github.com/bsyzek/redmine-contracts-with-time-tracking-plugin'
  
-  menu :application_menu, :contracts, { :controller => :contracts, :action => :all }, :caption => :label_contracts, :if => Proc.new { User.current.logged? && User.current.allowed_to?(:view_all_contracts_for_project, nil, :global => true) } 
+  # This seems to be broken in the current plugin with Redmine 2.5
+  #menu :application_menu, :contracts, { :controller => :contracts, :action => :all }, :caption => :label_contracts, :if => Proc.new { User.current.logged? && User.current.allowed_to?(:view_all_contracts_for_project, nil, :global => true) } 
   menu :project_menu, :contracts, { :controller => :contracts, :action => :index }, :caption => :label_contracts, :param => :project_id
 
   project_module :contracts do


### PR DESCRIPTION
In Redmine 2.5 the contract page was displaying without the link to "New Contract". The page was accessible by changing the URL, but it's quite a cumbersome way to add new projects. Even though the current user was set to have permissions to add contracts, the button was not displaying.

I've changed the if statement that controls who should see the add new contract button. It now uses link_to_if_authorized, which is uses in the knowledge base plugin. It displays "New Contract" button correctly on our install.
